### PR TITLE
Fix README typo in LangChain-Poe module

### DIFF
--- a/langchain_poe/README.md
+++ b/langchain_poe/README.md
@@ -4,7 +4,7 @@ A demonstration bot built using LangChain.
 
 To use it:
 
-- Install the bot (for now: clone this repo, run `pip install .` in this dirctory)
+- Install the bot (for now: clone this repo, run `pip install .` in this directory)
 - Get an OpenAI API key
 - Run `OPENAI_API_KEY=your-api-key python3 -m langchain_poe`
 - Make your server publicly accessible (e.g., using `ngrok`)


### PR DESCRIPTION
## Summary
- correct a misspelling in `langchain_poe/README.md`

## Testing
- `pre-commit` *(fails: command not found)*